### PR TITLE
Add logging to training scripts

### DIFF
--- a/scripts/compare_runs.py
+++ b/scripts/compare_runs.py
@@ -1,0 +1,94 @@
+import argparse
+import json
+from pathlib import Path
+from typing import Tuple
+
+import matplotlib.pyplot as plt
+import torch
+
+from model import FFTNet
+from scripts.train_fresh import DummyWikiDataset
+from fftnet.utils.storage import load_model
+
+
+
+
+def load_losses(path: Path) -> Tuple[list[int], list[float]]:
+    steps: list[int] = []
+    losses: list[float] = []
+    if not path.exists():
+        return steps, losses
+    with open(path) as f:
+        for line in f:
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            steps.append(rec.get("step", len(steps) + 1))
+            losses.append(rec.get("loss", 0.0))
+    return steps, losses
+
+
+def average_logit_spectrum(model: FFTNet, dataset: DummyWikiDataset, num_batches: int = 5) -> torch.Tensor:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model.to(device)
+    loader = torch.utils.data.DataLoader(dataset, batch_size=4, shuffle=False)
+    mags = []
+    with torch.no_grad():
+        for i, batch in enumerate(loader):
+            if i >= num_batches:
+                break
+            batch = batch.to(device)
+            logits = model(batch)
+            freq = torch.fft.fft(logits, dim=1)
+            mag = freq.abs().mean(dim=(0, 2))
+            mags.append(mag.cpu())
+    return torch.stack(mags).mean(dim=0)
+
+
+def plot_comparison(args: argparse.Namespace) -> None:
+    fresh_steps, fresh_loss = load_losses(args.fresh_log)
+    distill_steps, distill_loss = load_losses(args.distill_log)
+
+    fig, axes = plt.subplots(1, 2, figsize=(10, 4))
+
+    axes[0].plot(fresh_steps, fresh_loss, label="fresh")
+    axes[0].plot(distill_steps, distill_loss, label="distill")
+    axes[0].set_xlabel("Step")
+    axes[0].set_ylabel("Loss")
+    axes[0].set_title("Training Loss")
+    axes[0].legend()
+
+    if args.fresh_model and args.distill_model:
+        dataset = DummyWikiDataset(seq_len=8)
+        fresh_model, _ = load_model(args.fresh_model)
+        distill_model, _ = load_model(args.distill_model)
+        fresh_fft = average_logit_spectrum(fresh_model, dataset)
+        distill_fft = average_logit_spectrum(distill_model, dataset)
+        axes[1].plot(fresh_fft.numpy(), label="fresh")
+        axes[1].plot(distill_fft.numpy(), label="distill")
+        axes[1].set_title("Average Logit Spectrum")
+        axes[1].set_xlabel("Frequency Index")
+        axes[1].set_ylabel("Magnitude")
+        axes[1].legend()
+    else:
+        axes[1].axis("off")
+
+    plt.tight_layout()
+    plt.savefig("training_comparison.png")
+    plt.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compare training logs")
+    parser.add_argument("--fresh-log", type=Path, default=Path("logs/fresh_run.jsonl"))
+    parser.add_argument("--distill-log", type=Path, default=Path("logs/distill_run.jsonl"))
+    parser.add_argument("--fresh-model", type=Path, help="Path to fresh model for FFT analysis")
+    parser.add_argument("--distill-model", type=Path, help="Path to distilled model for FFT analysis")
+    args = parser.parse_args()
+    plot_comparison(args)
+    print("Saved training_comparison.png")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -1,0 +1,114 @@
+import argparse
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, Subset
+from transformers import AutoModelForCausalLM
+
+from model import FFTNet
+from scripts.train_fresh import DummyWikiDataset
+from fftnet.utils.storage import load_model
+
+
+@torch.no_grad()
+def compute_spectrum(model: FFTNet, dataset: torch.utils.data.Dataset, cfg: dict) -> torch.Tensor:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    loader = DataLoader(dataset, batch_size=4, shuffle=False)
+    model.to(device)
+    mags = []
+    for i, batch in enumerate(loader):
+        if isinstance(batch, (list, tuple)):
+            batch = batch[0]
+        batch = batch.to(device)
+        logits = model(batch)
+        freq = torch.fft.fft(logits, dim=1)
+        mag = freq.abs().mean(dim=(0, 2))
+        mags.append(mag.cpu())
+    return torch.stack(mags).mean(dim=0)
+
+
+@torch.no_grad()
+def evaluate(model: FFTNet, dataset: torch.utils.data.Dataset, cfg: dict, args: argparse.Namespace):
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    loader = DataLoader(dataset, batch_size=args.batch_size, shuffle=False)
+    model.to(device)
+    loss_fn = nn.CrossEntropyLoss()
+    total_loss = 0.0
+    correct = 0
+    count = 0
+
+    teacher_loss = 0.0
+    teacher = None
+    if args.teacher_model:
+        teacher = AutoModelForCausalLM.from_pretrained(args.teacher_model).to(device)
+        teacher.eval()
+        dist_loss_fn = nn.MSELoss()
+
+    for batch in loader:
+        if isinstance(batch, (list, tuple)):
+            x, y = batch
+        else:
+            x, y = batch, batch
+        x = x.to(device)
+        y = y.to(device)
+        logits = model(x)
+        logits = logits.view(-1, cfg["vocab_size"])
+        targets = y.view(-1)
+        loss = loss_fn(logits, targets)
+        total_loss += loss.item() * targets.numel()
+        preds = logits.argmax(dim=-1)
+        correct += (preds == targets).sum().item()
+        count += targets.numel()
+        if teacher is not None:
+            teach_logits = teacher(x).logits[..., : cfg["vocab_size"]]
+            tloss = dist_loss_fn(logits, teach_logits.view(-1, cfg["vocab_size"]))
+            teacher_loss += tloss.item() * targets.numel()
+
+    results = {
+        "loss": total_loss / count,
+        "accuracy": correct / count,
+    }
+    if teacher is not None:
+        results["teacher_similarity"] = teacher_loss / count
+    return results
+
+
+def plot_and_save_spectrum(spectrum: torch.Tensor, output_path: Path) -> None:
+    plt.figure()
+    plt.plot(spectrum.numpy())
+    plt.xlabel("Frequency index")
+    plt.ylabel("Magnitude")
+    plt.title("Average Logit Spectrum")
+    plt.tight_layout()
+    plt.savefig(output_path)
+    plt.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Evaluate a saved FFTNet model")
+    parser.add_argument("--model", required=True, help="Model version name")
+    parser.add_argument("--batch-size", type=int, default=8)
+    parser.add_argument("--seq-len", type=int, default=8)
+    parser.add_argument("--teacher-model", help="Optional teacher model for similarity")
+    args = parser.parse_args()
+
+    model, cfg = load_model(Path("weights") / args.model)
+    full_dataset = DummyWikiDataset(seq_len=args.seq_len)
+    test_indices = range(max(0, len(full_dataset) - 20), len(full_dataset))
+    test_dataset = Subset(full_dataset, list(test_indices))
+
+    results = evaluate(model, test_dataset, cfg, args)
+    spectrum = compute_spectrum(model, test_dataset, cfg)
+    plot_and_save_spectrum(spectrum, Path("evaluate_spectrum.png"))
+
+    for k, v in results.items():
+        print(f"{k}: {v:.4f}")
+    print("Saved evaluate_spectrum.png")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train_distill.py
+++ b/scripts/train_distill.py
@@ -1,0 +1,127 @@
+import argparse
+import json
+import time
+from pathlib import Path
+
+import torch
+from torch import nn
+from torch.utils.data import Dataset, DataLoader
+from transformers import AutoModelForCausalLM
+
+from model import FFTNet
+from fftnet.utils.storage import save_model, load_model
+
+
+class DummyWikiDataset(Dataset):
+    """Very small dataset of repeated words."""
+
+    VOCAB = [
+        "the",
+        "quick",
+        "brown",
+        "fox",
+        "jumps",
+        "over",
+        "lazy",
+        "dog",
+        "lorem",
+        "ipsum",
+    ]
+    WORD_TO_ID = {w: i for i, w in enumerate(VOCAB)}
+
+    def __init__(self, seq_len: int) -> None:
+        text = ("the quick brown fox jumps over lazy dog lorem ipsum " * 100).strip()
+        ids = [self.WORD_TO_ID[w] for w in text.split()]
+        self.seq_len = seq_len
+        self.seqs = [ids[i : i + seq_len] for i in range(len(ids) - seq_len)]
+
+    def __len__(self) -> int:
+        return len(self.seqs)
+
+    def __getitem__(self, idx: int):
+        x = torch.tensor(self.seqs[idx], dtype=torch.long)
+        return x
+
+
+def distill(model: FFTNet, teacher: AutoModelForCausalLM, dataset: Dataset, cfg: dict, args: argparse.Namespace) -> None:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model.to(device)
+    teacher.to(device)
+    teacher.eval()
+    for p in teacher.parameters():
+        p.requires_grad = False
+
+    loader = DataLoader(dataset, batch_size=args.batch_size, shuffle=True)
+    opt = torch.optim.Adam(model.parameters(), lr=args.lr)
+    loss_fn = nn.MSELoss()
+
+    log_path = Path("logs/distill_run.jsonl")
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    step = 0
+
+    with log_path.open("w") as log_file:
+        for epoch in range(1, args.epochs + 1):
+            total = 0.0
+            correct = 0
+            count = 0
+            for batch in loader:
+                batch = batch.to(device)
+                opt.zero_grad()
+                with torch.no_grad():
+                    teach_logits = teacher(batch).logits[..., : cfg["vocab_size"]]
+                stud_logits = model(batch)
+                loss = loss_fn(stud_logits, teach_logits)
+                loss.backward()
+                opt.step()
+                total += loss.item() * batch.size(0)
+
+                preds = stud_logits.argmax(dim=-1)
+                teach_preds = teach_logits.argmax(dim=-1)
+                correct += (preds == teach_preds).sum().item()
+                count += batch.numel()
+
+                step += 1
+                entry = {
+                    "step": step,
+                    "epoch": epoch,
+                    "loss": loss.item(),
+                    "accuracy": (preds == teach_preds).float().mean().item(),
+                    "timestamp": time.time(),
+                }
+                log_file.write(json.dumps(entry) + "\n")
+
+            epoch_loss = total / (len(loader.dataset))
+            epoch_acc = correct / count if count else 0.0
+            print(f"Epoch {epoch}: distill_loss={epoch_loss:.4f} acc={epoch_acc:.4f}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Distill GPT2 into FFTNet")
+    parser.add_argument("--resume", metavar="VERSION", help="Resume FFTNet", nargs="?")
+    parser.add_argument("--epochs", type=int, default=3)
+    parser.add_argument("--batch-size", type=int, default=8)
+    parser.add_argument("--seq-len", type=int, default=8)
+    parser.add_argument("--lr", type=float, default=1e-3)
+    parser.add_argument("--teacher-model", default="gpt2")
+    parser.add_argument("--save-name", default="distilled")
+    args = parser.parse_args()
+
+    if args.resume:
+        model, cfg = load_model(Path("weights") / args.resume)
+    else:
+        with open("config/fiftynet_config.json") as f:
+            cfg = json.load(f)
+        model = FFTNet(**{k: cfg[k] for k in ("vocab_size", "dim", "num_blocks")})
+
+    teacher = AutoModelForCausalLM.from_pretrained(args.teacher_model)
+    dataset = DummyWikiDataset(seq_len=args.seq_len)
+
+    distill(model, teacher, dataset, cfg, args)
+
+    save_path = Path("weights") / args.save_name
+    save_model(model, str(save_path), cfg)
+    print(f"Model saved to {save_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train_fresh.py
+++ b/scripts/train_fresh.py
@@ -1,0 +1,122 @@
+import argparse
+import json
+import time
+from pathlib import Path
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, Dataset
+
+from model import FFTNet
+from fftnet.utils.storage import save_model, load_model
+
+
+class DummyWikiDataset(Dataset):
+    """Simple token dataset built from a tiny Wikipedia-like text."""
+
+    VOCAB = [
+        "the",
+        "quick",
+        "brown",
+        "fox",
+        "jumps",
+        "over",
+        "lazy",
+        "dog",
+        "lorem",
+        "ipsum",
+    ]
+
+    WORD_TO_ID = {w: i for i, w in enumerate(VOCAB)}
+
+    def __init__(self, seq_len: int) -> None:
+        sample_text = (
+            "the quick brown fox jumps over lazy dog lorem ipsum " * 100
+        ).strip()
+        tokens = [self.WORD_TO_ID[w] for w in sample_text.split()]
+        self.seq_len = seq_len
+        self.seqs = [tokens[i : i + seq_len + 1] for i in range(len(tokens) - seq_len)]
+
+    def __len__(self) -> int:
+        return len(self.seqs)
+
+    def __getitem__(self, idx: int):
+        seq = self.seqs[idx]
+        x = torch.tensor(seq[:-1], dtype=torch.long)
+        y = torch.tensor(seq[1:], dtype=torch.long)
+        return x, y
+
+
+def train(model: FFTNet, dataset: Dataset, cfg: dict, args: argparse.Namespace) -> None:
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model.to(device)
+    loader = DataLoader(dataset, batch_size=args.batch_size, shuffle=True)
+    opt = torch.optim.Adam(model.parameters(), lr=args.lr)
+    loss_fn = nn.CrossEntropyLoss()
+
+    log_path = Path("logs/fresh_run.jsonl")
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    step = 0
+
+    with log_path.open("w") as log_file:
+        for epoch in range(1, args.epochs + 1):
+            total_loss = 0.0
+            correct = 0
+            count = 0
+            for x, y in loader:
+                x = x.to(device)
+                y = y.to(device)
+                opt.zero_grad()
+                logits = model(x)
+                logits = logits.view(-1, cfg["vocab_size"])
+                targets = y.view(-1)
+                loss = loss_fn(logits, targets)
+                loss.backward()
+                opt.step()
+                total_loss += loss.item() * targets.numel()
+                preds = logits.argmax(dim=-1)
+                correct += (preds == targets).sum().item()
+                count += targets.numel()
+
+                step += 1
+                entry = {
+                    "step": step,
+                    "epoch": epoch,
+                    "loss": loss.item(),
+                    "accuracy": (preds == targets).float().mean().item(),
+                    "timestamp": time.time(),
+                }
+                log_file.write(json.dumps(entry) + "\n")
+
+            avg_loss = total_loss / count
+            acc = correct / count
+            print(f"Epoch {epoch}: loss={avg_loss:.4f} acc={acc:.4f}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train FFTNet from scratch")
+    parser.add_argument("--resume", metavar="VERSION", help="Resume from saved model", nargs="?")
+    parser.add_argument("--epochs", type=int, default=5)
+    parser.add_argument("--batch-size", type=int, default=8)
+    parser.add_argument("--seq-len", type=int, default=8)
+    parser.add_argument("--lr", type=float, default=1e-3)
+    parser.add_argument("--save-name", default="trained", help="Version name to save")
+    args = parser.parse_args()
+
+    if args.resume:
+        model, cfg = load_model(Path("weights") / args.resume)
+    else:
+        with open("config/fiftynet_config.json") as f:
+            cfg = json.load(f)
+        model = FFTNet(**{k: cfg[k] for k in ("vocab_size", "dim", "num_blocks")})
+
+    dataset = DummyWikiDataset(seq_len=args.seq_len)
+    train(model, dataset, cfg, args)
+
+    save_path = Path("weights") / args.save_name
+    save_model(model, str(save_path), cfg)
+    print(f"Model saved to {save_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- log each training step to `logs/fresh_run.jsonl` or `logs/distill_run.jsonl`
- update `compare_runs.py` to parse the JSONL logs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6886fc58b888832480dd2f25642b52b1