### PR TITLE
docs: add roadmap and tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # Fiftynet
 FFT-Net (Hybrid Transformer with Frequency Processing)
+
+A minimal research model that mixes tokens in the frequency domain using rotary position embeddings and learnable spectral filters.
+
+See [ROADMAP.md](ROADMAP.md) for planned milestones and [TASKS.md](TASKS.md) for current progress.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,18 @@
+# FFTNet Roadmap
+
+## Completed
+- ComplexRoPE applies log-scaled rotary position encoding in the complex domain.
+- NeuralFourierOperator learns a complex frequency filter for global token mixing.
+- FFTNetBlock chains rotary encoding, FFT, learned filtering, inverse FFT, and an MLP.
+- FFTNet stacks multiple blocks with token embeddings and a projection head.
+- Scripts support training from scratch, GPT-2 distillation, evaluation, and model management.
+- Utilities save and load weights using `safetensors` while preserving complex parameters.
+- Unit tests cover core modules and visualizations.
+
+## Next Steps
+1. **Data & Tokenization** – replace the dummy dataset with real corpora and configurable tokenizers.
+2. **Configuration** – expand JSON/YAML configs to allow flexible block types and hyperparameters.
+3. **Training** – add mixed-precision support, checkpointing, and richer logging.
+4. **Evaluation** – integrate standard benchmarks and teacher-student similarity metrics.
+5. **Deployment** – package inference as a CLI/API and publish example pretrained weights.
+6. **Extensions** – explore alternative spectral operators (e.g., wavelets) or attention hybrids.

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,20 @@
+# Project Tasks
+
+## Implemented
+- [x] ComplexRoPE for complex rotary embeddings.
+- [x] NeuralFourierOperator for frequency-domain filtering.
+- [x] FFTNetBlock combining FFT-based processing with an MLP and residual connection.
+- [x] FFTNet model that stacks blocks with token embeddings and a projection head.
+- [x] Training scripts for fresh models and GPT-2 distillation.
+- [x] Model persistence via `safetensors` with complex tensor handling.
+- [x] Evaluation, visualization, and model management utilities.
+- [x] Test suite covering core components and visualizations.
+
+## TODO
+- [ ] Replace `DummyWikiDataset` with modular data loaders and real corpora.
+- [ ] Provide tokenizer and vocabulary management utilities.
+- [ ] Extend configuration loading to parse block definitions from YAML.
+- [ ] Enhance training loops with mixed precision, checkpointing, and early stopping.
+- [ ] Package inference as a CLI/API and distribute example pretrained weights.
+- [ ] Add benchmarks and performance regression tests.
+- [ ] Expand README with usage examples and architecture details.


### PR DESCRIPTION
## Summary
- add project roadmap outlining completed components and future milestones
- track implemented features and outstanding work in new tasks list
- link roadmap and task tracker from the README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688e279b180c83248f3799990bc9ec53