### PR TITLE
Add basic byte-level BPE tokenizer and YAML config loader

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -12,8 +12,8 @@
 
 ## TODO
 - [ ] Replace `DummyWikiDataset` with modular data loaders and real corpora.
-- [ ] Provide tokenizer and vocabulary management utilities.
-- [ ] Extend configuration loading to parse block definitions from YAML.
+- [x] Provide tokenizer and vocabulary management utilities.
+- [x] Extend configuration loading to parse block definitions from YAML.
 - [ ] Enhance training loops with mixed precision, checkpointing, and early stopping.
 - [ ] Package inference as a CLI/API and distribute example pretrained weights.
 - [ ] Add benchmarks and performance regression tests.

--- a/fftnet/utils/config.py
+++ b/fftnet/utils/config.py
@@ -1,0 +1,61 @@
+import json
+from typing import Any, Dict, Tuple
+
+import yaml
+from torch import nn
+
+from model import FFTNet
+from fftnet_block import FFTNetBlock
+
+# Registry mapping string names to block classes
+BLOCK_REGISTRY = {
+    "FFTNetBlock": FFTNetBlock,
+}
+
+
+def load_config(config_path: str, modules_path: str) -> Dict[str, Any]:
+    """Load base configuration and block definitions.
+
+    Parameters
+    ----------
+    config_path: str
+        Path to a JSON file containing base hyperparameters.
+    modules_path: str
+        Path to a YAML file defining the model's blocks.
+    """
+    with open(config_path, "r") as f:
+        cfg = json.load(f)
+    with open(modules_path, "r") as f:
+        modules = yaml.safe_load(f) or {}
+    blocks = modules.get("blocks", [])
+    cfg["blocks"] = blocks
+    cfg["num_blocks"] = len(blocks)
+    return cfg
+
+
+def build_model_from_config(cfg: Dict[str, Any]) -> FFTNet:
+    """Instantiate an ``FFTNet`` from a configuration dictionary."""
+    blocks = []
+    if "blocks" in cfg:
+        for block_cfg in cfg["blocks"]:
+            block_type = block_cfg["type"]
+            block_cls = BLOCK_REGISTRY.get(block_type)
+            if block_cls is None:
+                raise ValueError(f"Unknown block type {block_type}")
+            params = {k: v for k, v in block_cfg.items() if k not in {"type", "name"}}
+            blocks.append(block_cls(cfg["dim"], **params))
+        num_blocks = len(blocks)
+    else:
+        num_blocks = int(cfg.get("num_blocks", 0))
+        blocks = [FFTNetBlock(cfg["dim"]) for _ in range(num_blocks)]
+
+    model = FFTNet(cfg["vocab_size"], cfg["dim"], num_blocks)
+    model.blocks = nn.ModuleList(blocks)
+    return model
+
+
+def build_model(config_path: str, modules_path: str) -> Tuple[FFTNet, Dict[str, Any]]:
+    """Load configuration files and build the corresponding model."""
+    cfg = load_config(config_path, modules_path)
+    model = build_model_from_config(cfg)
+    return model, cfg

--- a/fftnet/utils/storage.py
+++ b/fftnet/utils/storage.py
@@ -6,7 +6,7 @@ import torch
 from torch import nn
 from safetensors.torch import save_file, safe_open
 
-from model import FFTNet
+from .config import build_model_from_config
 
 
 def _prepare_state_for_save(state: dict) -> tuple[dict, list[str]]:
@@ -58,6 +58,6 @@ def load_model(path: str) -> Tuple[nn.Module, dict]:
         for k in f.keys():
             tensors[k] = f.get_tensor(k)
     tensors = _restore_complex(tensors, complex_keys)
-    model = FFTNet(**{k: config[k] for k in ('vocab_size', 'dim', 'num_blocks')})
+    model = build_model_from_config(config)
     model.load_state_dict(tensors)
     return model, config

--- a/fftnet_infer.py
+++ b/fftnet_infer.py
@@ -1,5 +1,4 @@
 import argparse
-import json
 import os
 import sys
 from pathlib import Path
@@ -35,6 +34,7 @@ except Exception:  # pragma: no cover
 
 from model import FFTNet
 from fftnet.utils import storage
+from fftnet.utils.config import build_model
 
 
 def _tokenize(prompt: str) -> list[int]:
@@ -73,9 +73,9 @@ def main() -> None:
     if args.model:
         model, cfg = storage.load_model(Path("weights") / args.model)
     else:
-        with open("config/fiftynet_config.json") as f:
-            cfg = json.load(f)
-        model = FFTNet(**{k: cfg[k] for k in ("vocab_size", "dim", "num_blocks")})
+        model, cfg = build_model(
+            "config/fiftynet_config.json", "config/fiftynet_modules.yaml"
+        )
 
     tokens = _tokenize(args.prompt)
     input_ids = torch.tensor(tokens, dtype=torch.long).unsqueeze(0)

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -1,11 +1,10 @@
 import argparse
-import json
 import sys
 import torch
 import matplotlib.pyplot as plt
 
-from model import FFTNet
 from fftnet.utils import storage
+from fftnet.utils.config import build_model
 
 
 def plot_embedding_spectrum(embeddings: torch.Tensor) -> None:
@@ -40,9 +39,9 @@ def main() -> None:
             print(f"Model {args.model} not found", file=sys.stderr)
             return
     else:
-        with open("config/fiftynet_config.json") as f:
-            cfg = json.load(f)
-        model = FFTNet(**{k: cfg[k] for k in ("vocab_size", "dim", "num_blocks")})
+        model, cfg = build_model(
+            "config/fiftynet_config.json", "config/fiftynet_modules.yaml"
+        )
 
     input_ids = torch.randint(0, cfg["vocab_size"], (1, 8))
     embeddings = model.embedding(input_ids)

--- a/scripts/train_distill.py
+++ b/scripts/train_distill.py
@@ -8,7 +8,7 @@ from torch import nn
 from torch.utils.data import Dataset, DataLoader
 from transformers import AutoModelForCausalLM
 
-from model import FFTNet
+from fftnet.utils.config import build_model
 from fftnet.utils.storage import save_model, load_model
 
 
@@ -109,9 +109,9 @@ def main() -> None:
     if args.resume:
         model, cfg = load_model(Path("weights") / args.resume)
     else:
-        with open("config/fiftynet_config.json") as f:
-            cfg = json.load(f)
-        model = FFTNet(**{k: cfg[k] for k in ("vocab_size", "dim", "num_blocks")})
+        model, cfg = build_model(
+            "config/fiftynet_config.json", "config/fiftynet_modules.yaml"
+        )
 
     teacher = AutoModelForCausalLM.from_pretrained(args.teacher_model)
     dataset = DummyWikiDataset(seq_len=args.seq_len)

--- a/scripts/train_fresh.py
+++ b/scripts/train_fresh.py
@@ -7,7 +7,7 @@ import torch
 from torch import nn
 from torch.utils.data import DataLoader, Dataset
 
-from model import FFTNet
+from fftnet.utils.config import build_model
 from fftnet.utils.storage import save_model, load_model
 
 
@@ -106,9 +106,9 @@ def main() -> None:
     if args.resume:
         model, cfg = load_model(Path("weights") / args.resume)
     else:
-        with open("config/fiftynet_config.json") as f:
-            cfg = json.load(f)
-        model = FFTNet(**{k: cfg[k] for k in ("vocab_size", "dim", "num_blocks")})
+        model, cfg = build_model(
+            "config/fiftynet_config.json", "config/fiftynet_modules.yaml"
+        )
 
     dataset = DummyWikiDataset(seq_len=args.seq_len)
     train(model, dataset, cfg, args)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,20 @@
+import json
+
+from fftnet.utils.config import build_model, load_config
+
+
+def test_build_model_from_yaml(tmp_path):
+    cfg_json = tmp_path / "cfg.json"
+    modules_yaml = tmp_path / "modules.yaml"
+    cfg_json.write_text(json.dumps({"vocab_size": 10, "dim": 4}))
+    modules_yaml.write_text(
+        "blocks:\n" "  - type: FFTNetBlock\n" "    name: block0\n" "    base: 123\n" "  - type: FFTNetBlock\n" "    name: block1\n"
+    )
+
+    model, cfg = build_model(str(cfg_json), str(modules_yaml))
+    assert cfg["num_blocks"] == 2
+    assert len(model.blocks) == 2
+    assert model.blocks[0].rope.base == 123
+
+    loaded_cfg = load_config(str(cfg_json), str(modules_yaml))
+    assert loaded_cfg["blocks"][1]["name"] == "block1"

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from tokenizer import SimpleTokenizer
+
+
+def test_train_encode_decode(tmp_path):
+    corpus = ["hello world", "hello there"]
+    tokenizer = SimpleTokenizer.train_from_iterator(corpus, vocab_size=100)
+
+    ids = tokenizer.encode("hello world")
+    assert tokenizer.decode(ids) == "hello world"
+
+    path = tmp_path / "tokenizer.json"
+    tokenizer.save(str(path))
+
+    loaded = SimpleTokenizer.load(str(path))
+    assert loaded.decode(ids) == "hello world"
+    assert len(loaded) == len(tokenizer)

--- a/tokenizer.py
+++ b/tokenizer.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+from tokenizers import Tokenizer, decoders, models, pre_tokenizers, processors, trainers
+
+
+@dataclass
+class SimpleTokenizer:
+    """Byte-level BPE tokenizer with minimal persistence helpers.
+
+    This wrapper is intentionally lightweight.  It exposes the methods needed
+    by the training scripts while keeping the underlying HuggingFace tokenizer
+    configurable for future extensions.
+    """
+
+    tokenizer: Tokenizer
+
+    @classmethod
+    def train_from_iterator(
+        cls,
+        iterator: Iterable[str],
+        vocab_size: int = 5000,
+        min_frequency: int = 2,
+        special_tokens: Sequence[str] = ("<pad>", "<unk>", "<bos>", "<eos>"),
+    ) -> "SimpleTokenizer":
+        """Train a byte-level BPE tokenizer from an iterable of texts.
+
+        Args:
+            iterator: Iterable yielding strings for training.
+            vocab_size: Target vocabulary size.
+            min_frequency: Minimum frequency for merges.
+            special_tokens: Tokens always kept in the vocabulary.
+        """
+
+        tok = Tokenizer(models.BPE(unk_token="<unk>"))
+        tok.pre_tokenizer = pre_tokenizers.ByteLevel()
+        trainer = trainers.BpeTrainer(
+            vocab_size=vocab_size,
+            min_frequency=min_frequency,
+            special_tokens=list(special_tokens),
+        )
+        tok.train_from_iterator(iterator, trainer=trainer)
+        tok.post_processor = processors.ByteLevel(trim_offsets=False)
+        tok.decoder = decoders.ByteLevel()
+        return cls(tok)
+
+    def encode(self, text: str) -> List[int]:
+        """Encode a string into token ids."""
+
+        return self.tokenizer.encode(text).ids
+
+    def decode(self, ids: Sequence[int]) -> str:
+        """Decode token ids into a string.
+
+        The underlying byte-level tokenizer includes a leading space token.
+        Stripping the result provides a more conventional text round-trip.
+        """
+
+        return self.tokenizer.decode(ids).strip()
+
+    def save(self, path: str) -> None:
+        """Serialize the tokenizer to ``path``."""
+
+        self.tokenizer.save(path)
+
+    @classmethod
+    def load(cls, path: str) -> "SimpleTokenizer":
+        """Load a previously saved tokenizer from ``path``."""
+
+        return cls(Tokenizer.from_file(path))
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return self.tokenizer.get_vocab_size()


### PR DESCRIPTION
## Summary
- introduce YAML-based config loader to build FFTNet blocks from module definitions
- wire storage, training, and inference scripts to create models via the new loader
- test configuration loading and mark tokenizer & config tasks complete

## Testing
- `pip install pyyaml`
- `pip install torch tokenizers`
- `pip install safetensors matplotlib numpy`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e29fc670c8324a15608ff1654abf6