### PR TITLE
docs: document features and roadmap

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,0 +1,16 @@
+# FFTNet Features
+
+A quick overview of the capabilities currently implemented in FFTNet.
+
+## Core Architecture
+- **ComplexRoPE** adds log-scaled rotary positional encoding in the complex domain.
+- **NeuralFourierOperator** applies a learnable complex frequency filter for global token mixing.
+- **FFTNetBlock** chains rotary encoding, FFT, learned filtering, inverse FFT, and an MLP.
+- **FFTNet model** stacks multiple blocks around token embeddings and a projection head.
+
+## Tooling & Utilities
+- Scripts support training from scratch, GPT-2 distillation, evaluation, and model management.
+- Utilities save and load weights with `safetensors` while preserving complex parameters.
+- Unit tests cover core modules and visualization routines.
+
+See [ROADMAP.md](ROADMAP.md) for upcoming milestones.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@ FFT-Net (Hybrid Transformer with Frequency Processing)
 
 A minimal research model that mixes tokens in the frequency domain using rotary position embeddings and learnable spectral filters.
 
+## Features
+
+- ComplexRoPE rotary positional encoding in the complex domain.
+- Learnable frequency filtering via NeuralFourierOperator.
+- FFTNet blocks that combine FFT/IFFT with MLP layers.
+- Scripts for training, distillation, evaluation, and model management.
+- Weight I/O using `safetensors` with complex parameter support.
+
+See [FEATURES.md](FEATURES.md) for a more detailed list.
+
 ## Installation
 
 1. (Optional) create and activate a virtual environment.


### PR DESCRIPTION
## Summary
- add standalone feature overview for FFTNet with cross-link to roadmap
- mention major capabilities in README and link to feature list

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f5abe040c8324bb8f7d2a38ee880a