### PR TITLE
Add mixed precision and early stopping to training scripts

### DIFF
--- a/scripts/train_distill.py
+++ b/scripts/train_distill.py
@@ -5,9 +5,11 @@ from pathlib import Path
 
 import torch
 from torch import nn
-from torch.utils.data import Dataset, DataLoader
+from torch.cuda.amp import GradScaler, autocast
+from torch.utils.data import Dataset, DataLoader, random_split
 from transformers import AutoModelForCausalLM
 
+from model import FFTNet
 from fftnet.utils.config import build_model
 from fftnet.utils.storage import save_model, load_model
 
@@ -43,7 +45,14 @@ class DummyWikiDataset(Dataset):
         return x
 
 
-def distill(model: FFTNet, teacher: AutoModelForCausalLM, dataset: Dataset, cfg: dict, args: argparse.Namespace) -> None:
+def distill(
+    model: FFTNet,
+    teacher: AutoModelForCausalLM,
+    train_ds: Dataset,
+    val_ds: Dataset | None,
+    cfg: dict,
+    args: argparse.Namespace,
+) -> None:
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model.to(device)
     teacher.to(device)
@@ -51,28 +60,37 @@ def distill(model: FFTNet, teacher: AutoModelForCausalLM, dataset: Dataset, cfg:
     for p in teacher.parameters():
         p.requires_grad = False
 
-    loader = DataLoader(dataset, batch_size=args.batch_size, shuffle=True)
+    train_loader = DataLoader(train_ds, batch_size=args.batch_size, shuffle=True)
+    val_loader = (
+        DataLoader(val_ds, batch_size=args.batch_size) if val_ds is not None else None
+    )
     opt = torch.optim.Adam(model.parameters(), lr=args.lr)
     loss_fn = nn.MSELoss()
+    scaler = GradScaler(enabled=args.mixed_precision)
 
     log_path = Path("logs/distill_run.jsonl")
     log_path.parent.mkdir(parents=True, exist_ok=True)
     step = 0
+    best_val = float("inf")
+    patience_cntr = 0
 
     with log_path.open("w") as log_file:
         for epoch in range(1, args.epochs + 1):
+            model.train()
             total = 0.0
             correct = 0
             count = 0
-            for batch in loader:
+            for batch in train_loader:
                 batch = batch.to(device)
                 opt.zero_grad()
-                with torch.no_grad():
-                    teach_logits = teacher(batch).logits[..., : cfg["vocab_size"]]
-                stud_logits = model(batch)
-                loss = loss_fn(stud_logits, teach_logits)
-                loss.backward()
-                opt.step()
+                with autocast(enabled=args.mixed_precision):
+                    with torch.no_grad():
+                        teach_logits = teacher(batch).logits[..., : cfg["vocab_size"]]
+                    stud_logits = model(batch)
+                    loss = loss_fn(stud_logits, teach_logits)
+                scaler.scale(loss).backward()
+                scaler.step(opt)
+                scaler.update()
                 total += loss.item() * batch.size(0)
 
                 preds = stud_logits.argmax(dim=-1)
@@ -90,9 +108,54 @@ def distill(model: FFTNet, teacher: AutoModelForCausalLM, dataset: Dataset, cfg:
                 }
                 log_file.write(json.dumps(entry) + "\n")
 
-            epoch_loss = total / (len(loader.dataset))
+            epoch_loss = total / (len(train_loader.dataset))
             epoch_acc = correct / count if count else 0.0
-            print(f"Epoch {epoch}: distill_loss={epoch_loss:.4f} acc={epoch_acc:.4f}")
+            print(
+                f"Epoch {epoch}: distill_loss={epoch_loss:.4f} acc={epoch_acc:.4f}"
+            )
+
+            if val_loader is not None:
+                model.eval()
+                v_total = 0.0
+                v_correct = 0
+                v_count = 0
+                with torch.no_grad():
+                    for batch in val_loader:
+                        batch = batch.to(device)
+                        with autocast(enabled=args.mixed_precision):
+                            teach_logits = teacher(batch).logits[..., : cfg["vocab_size"]]
+                            stud_logits = model(batch)
+                            v_loss = loss_fn(stud_logits, teach_logits)
+                        v_total += v_loss.item() * batch.size(0)
+                        preds = stud_logits.argmax(dim=-1)
+                        teach_preds = teach_logits.argmax(dim=-1)
+                        v_correct += (preds == teach_preds).sum().item()
+                        v_count += batch.numel()
+
+                val_loss = v_total / len(val_loader.dataset)
+                val_acc = v_correct / v_count if v_count else 0.0
+                print(
+                    f"Validation: distill_loss={val_loss:.4f} acc={val_acc:.4f}"
+                )
+                val_entry = {
+                    "step": step,
+                    "epoch": epoch,
+                    "val_loss": val_loss,
+                    "val_accuracy": val_acc,
+                    "timestamp": time.time(),
+                }
+                log_file.write(json.dumps(val_entry) + "\n")
+
+                if val_loss < best_val:
+                    best_val = val_loss
+                    patience_cntr = 0
+                    if args.checkpoint_path is not None:
+                        save_model(model, str(args.checkpoint_path), cfg)
+                else:
+                    patience_cntr += 1
+                    if args.patience and patience_cntr >= args.patience:
+                        print("Early stopping triggered")
+                        break
 
 
 def main() -> None:
@@ -104,6 +167,28 @@ def main() -> None:
     parser.add_argument("--lr", type=float, default=1e-3)
     parser.add_argument("--teacher-model", default="gpt2")
     parser.add_argument("--save-name", default="distilled")
+    parser.add_argument(
+        "--mixed-precision",
+        action="store_true",
+        help="Enable mixed precision training",
+    )
+    parser.add_argument(
+        "--val-split",
+        type=float,
+        default=0.1,
+        help="Fraction of data reserved for validation",
+    )
+    parser.add_argument(
+        "--patience",
+        type=int,
+        default=0,
+        help="Early stopping patience (0 to disable)",
+    )
+    parser.add_argument(
+        "--checkpoint-path",
+        default=None,
+        help="Where to save best model checkpoint",
+    )
     args = parser.parse_args()
 
     if args.resume:
@@ -115,8 +200,16 @@ def main() -> None:
 
     teacher = AutoModelForCausalLM.from_pretrained(args.teacher_model)
     dataset = DummyWikiDataset(seq_len=args.seq_len)
+    val_size = int(len(dataset) * args.val_split)
+    train_size = len(dataset) - val_size
+    train_ds, val_ds = random_split(dataset, [train_size, val_size])
 
-    distill(model, teacher, dataset, cfg, args)
+    if args.checkpoint_path is None:
+        args.checkpoint_path = Path("weights") / f"{args.save_name}_best"
+    else:
+        args.checkpoint_path = Path(args.checkpoint_path)
+
+    distill(model, teacher, train_ds, val_ds, cfg, args)
 
     save_path = Path("weights") / args.save_name
     save_model(model, str(save_path), cfg)

--- a/scripts/train_fresh.py
+++ b/scripts/train_fresh.py
@@ -5,7 +5,8 @@ from pathlib import Path
 
 import torch
 from torch import nn
-from torch.utils.data import DataLoader, Dataset
+from torch.cuda.amp import GradScaler, autocast
+from torch.utils.data import DataLoader, Dataset, random_split
 
 from model import FFTNet
 from fftnet.data import TextFileDataset
@@ -14,32 +15,47 @@ from fftnet.utils.storage import save_model, load_model
 from tokenizer import SimpleTokenizer
 
 
-def train(model: FFTNet, dataset: Dataset, cfg: dict, args: argparse.Namespace) -> None:
+def train(
+    model: FFTNet,
+    train_ds: Dataset,
+    val_ds: Dataset | None,
+    cfg: dict,
+    args: argparse.Namespace,
+) -> None:
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     model.to(device)
-    loader = DataLoader(dataset, batch_size=args.batch_size, shuffle=True)
+    train_loader = DataLoader(train_ds, batch_size=args.batch_size, shuffle=True)
+    val_loader = (
+        DataLoader(val_ds, batch_size=args.batch_size) if val_ds is not None else None
+    )
     opt = torch.optim.Adam(model.parameters(), lr=args.lr)
     loss_fn = nn.CrossEntropyLoss()
+    scaler = GradScaler(enabled=args.mixed_precision)
 
     log_path = Path("logs/fresh_run.jsonl")
     log_path.parent.mkdir(parents=True, exist_ok=True)
     step = 0
+    best_val = float("inf")
+    patience_cntr = 0
 
     with log_path.open("w") as log_file:
         for epoch in range(1, args.epochs + 1):
+            model.train()
             total_loss = 0.0
             correct = 0
             count = 0
-            for x, y in loader:
+            for x, y in train_loader:
                 x = x.to(device)
                 y = y.to(device)
                 opt.zero_grad()
-                logits = model(x)
-                logits = logits.view(-1, cfg["vocab_size"])
-                targets = y.view(-1)
-                loss = loss_fn(logits, targets)
-                loss.backward()
-                opt.step()
+                with autocast(enabled=args.mixed_precision):
+                    logits = model(x)
+                    logits = logits.view(-1, cfg["vocab_size"])
+                    targets = y.view(-1)
+                    loss = loss_fn(logits, targets)
+                scaler.scale(loss).backward()
+                scaler.step(opt)
+                scaler.update()
                 total_loss += loss.item() * targets.numel()
                 preds = logits.argmax(dim=-1)
                 correct += (preds == targets).sum().item()
@@ -59,6 +75,50 @@ def train(model: FFTNet, dataset: Dataset, cfg: dict, args: argparse.Namespace) 
             acc = correct / count
             print(f"Epoch {epoch}: loss={avg_loss:.4f} acc={acc:.4f}")
 
+            if val_loader is not None:
+                model.eval()
+                v_total = 0.0
+                v_correct = 0
+                v_count = 0
+                with torch.no_grad():
+                    for x, y in val_loader:
+                        x = x.to(device)
+                        y = y.to(device)
+                        with autocast(enabled=args.mixed_precision):
+                            logits = model(x)
+                            logits = logits.view(-1, cfg["vocab_size"])
+                            targets = y.view(-1)
+                            v_loss = loss_fn(logits, targets)
+                        v_total += v_loss.item() * targets.numel()
+                        preds = logits.argmax(dim=-1)
+                        v_correct += (preds == targets).sum().item()
+                        v_count += targets.numel()
+
+                val_loss = v_total / v_count
+                val_acc = v_correct / v_count
+                print(
+                    f"Validation: loss={val_loss:.4f} acc={val_acc:.4f}"
+                )
+                val_entry = {
+                    "step": step,
+                    "epoch": epoch,
+                    "val_loss": val_loss,
+                    "val_accuracy": val_acc,
+                    "timestamp": time.time(),
+                }
+                log_file.write(json.dumps(val_entry) + "\n")
+
+                if val_loss < best_val:
+                    best_val = val_loss
+                    patience_cntr = 0
+                    if args.checkpoint_path is not None:
+                        save_model(model, str(args.checkpoint_path), cfg)
+                else:
+                    patience_cntr += 1
+                    if args.patience and patience_cntr >= args.patience:
+                        print("Early stopping triggered")
+                        break
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Train FFTNet from scratch")
@@ -75,6 +135,32 @@ def main() -> None:
         help="Path to load/save the tokenizer",
     )
     parser.add_argument("--vocab-size", type=int, default=5000, help="Tokenizer vocab size")
+    parser.add_argument(
+        "--mixed-precision",
+        action="store_true",
+        help="Enable mixed precision training",
+    )
+    parser.add_argument(
+        "--val-data-path",
+        help="Optional path to validation text file",
+    )
+    parser.add_argument(
+        "--val-split",
+        type=float,
+        default=0.1,
+        help="Fraction of data for validation if no val-data-path provided",
+    )
+    parser.add_argument(
+        "--patience",
+        type=int,
+        default=0,
+        help="Early stopping patience (0 to disable)",
+    )
+    parser.add_argument(
+        "--checkpoint-path",
+        default=None,
+        help="Where to save best model checkpoint",
+    )
     args = parser.parse_args()
 
     if args.resume:
@@ -94,8 +180,21 @@ def main() -> None:
         cfg["vocab_size"] = len(tokenizer)
         model = build_model_from_config(cfg)
 
-    dataset = TextFileDataset(args.data_path, tokenizer, seq_len=args.seq_len)
-    train(model, dataset, cfg, args)
+    full_dataset = TextFileDataset(args.data_path, tokenizer, seq_len=args.seq_len)
+    if args.val_data_path:
+        val_dataset = TextFileDataset(args.val_data_path, tokenizer, seq_len=args.seq_len)
+        train_dataset = full_dataset
+    else:
+        val_size = int(len(full_dataset) * args.val_split)
+        train_size = len(full_dataset) - val_size
+        train_dataset, val_dataset = random_split(full_dataset, [train_size, val_size])
+
+    if args.checkpoint_path is None:
+        args.checkpoint_path = Path("weights") / f"{args.save_name}_best"
+    else:
+        args.checkpoint_path = Path(args.checkpoint_path)
+
+    train(model, train_dataset, val_dataset, cfg, args)
 
     save_path = Path("weights") / args.save_name
     save_model(model, str(save_path), cfg)


### PR DESCRIPTION
## Summary
- integrate torch.cuda.amp with GradScaler for mixed precision training in `train_fresh.py` and `train_distill.py`
- add validation checkpoints and early stopping tied to best validation loss
- expose CLI flags for mixed precision, early stopping, checkpoint path, and validation split

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689029c66dd48324a90ea35d3057a5b7