### PR TITLE
Replace dummy dataset with TextFileDataset in scripts

### DIFF
--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -10,8 +10,9 @@ from torch.utils.data import DataLoader, Subset
 from transformers import AutoModelForCausalLM
 
 from model import FFTNet
-from scripts.train_fresh import DummyWikiDataset
+from fftnet.data import TextFileDataset
 from fftnet.utils.storage import load_model
+from tokenizer import SimpleTokenizer
 
 
 @torch.no_grad()
@@ -94,10 +95,15 @@ def main() -> None:
     parser.add_argument("--batch-size", type=int, default=8)
     parser.add_argument("--seq-len", type=int, default=8)
     parser.add_argument("--teacher-model", help="Optional teacher model for similarity")
+    parser.add_argument("--data-path", required=True, help="Path to evaluation text file")
+    parser.add_argument(
+        "--tokenizer-path", default="tokenizer.json", help="Path to tokenizer"
+    )
     args = parser.parse_args()
 
     model, cfg = load_model(Path("weights") / args.model)
-    full_dataset = DummyWikiDataset(seq_len=args.seq_len)
+    tokenizer = SimpleTokenizer.load(args.tokenizer_path)
+    full_dataset = TextFileDataset(args.data_path, tokenizer, seq_len=args.seq_len)
     test_indices = range(max(0, len(full_dataset) - 20), len(full_dataset))
     test_dataset = Subset(full_dataset, list(test_indices))
 

--- a/scripts/train_distill.py
+++ b/scripts/train_distill.py
@@ -51,23 +51,23 @@ def distill(
             total = 0.0
             correct = 0
             count = 0
-            for x, _ in train_loader:
-                x = x.to(device)
+            for inputs, _ in train_loader:
+                inputs = inputs.to(device)
                 opt.zero_grad()
                 with autocast(enabled=args.mixed_precision):
                     with torch.no_grad():
-                        teach_logits = teacher(x).logits[..., : cfg["vocab_size"]]
-                    stud_logits = model(x)
+                        teach_logits = teacher(inputs).logits[..., : cfg["vocab_size"]]
+                    stud_logits = model(inputs)
                     loss = loss_fn(stud_logits, teach_logits)
                 scaler.scale(loss).backward()
                 scaler.step(opt)
                 scaler.update()
-                total += loss.item() * x.size(0)
+                total += loss.item() * inputs.size(0)
 
                 preds = stud_logits.argmax(dim=-1)
                 teach_preds = teach_logits.argmax(dim=-1)
                 correct += (preds == teach_preds).sum().item()
-                count += x.numel()
+                count += inputs.numel()
 
                 step += 1
                 entry = {
@@ -91,17 +91,17 @@ def distill(
                 v_correct = 0
                 v_count = 0
                 with torch.no_grad():
-                    for x, _ in val_loader:
-                        x = x.to(device)
+                    for inputs, _ in val_loader:
+                        inputs = inputs.to(device)
                         with autocast(enabled=args.mixed_precision):
-                            teach_logits = teacher(x).logits[..., : cfg["vocab_size"]]
-                            stud_logits = model(x)
+                            teach_logits = teacher(inputs).logits[..., : cfg["vocab_size"]]
+                            stud_logits = model(inputs)
                             v_loss = loss_fn(stud_logits, teach_logits)
-                        v_total += v_loss.item() * x.size(0)
+                        v_total += v_loss.item() * inputs.size(0)
                         preds = stud_logits.argmax(dim=-1)
                         teach_preds = teach_logits.argmax(dim=-1)
                         v_correct += (preds == teach_preds).sum().item()
-                        v_count += x.numel()
+                        v_count += inputs.numel()
 
                 val_loss = v_total / len(val_loader.dataset)
                 val_acc = v_correct / v_count if v_count else 0.0

--- a/scripts/train_distill.py
+++ b/scripts/train_distill.py
@@ -5,42 +5,14 @@ from pathlib import Path
 
 import torch
 from torch import nn
-from torch.utils.data import Dataset, DataLoader
+from torch.utils.data import DataLoader, Dataset
 from transformers import AutoModelForCausalLM
 
-from fftnet.utils.config import build_model
-from fftnet.utils.storage import save_model, load_model
-
-
-class DummyWikiDataset(Dataset):
-    """Very small dataset of repeated words."""
-
-    VOCAB = [
-        "the",
-        "quick",
-        "brown",
-        "fox",
-        "jumps",
-        "over",
-        "lazy",
-        "dog",
-        "lorem",
-        "ipsum",
-    ]
-    WORD_TO_ID = {w: i for i, w in enumerate(VOCAB)}
-
-    def __init__(self, seq_len: int) -> None:
-        text = ("the quick brown fox jumps over lazy dog lorem ipsum " * 100).strip()
-        ids = [self.WORD_TO_ID[w] for w in text.split()]
-        self.seq_len = seq_len
-        self.seqs = [ids[i : i + seq_len] for i in range(len(ids) - seq_len)]
-
-    def __len__(self) -> int:
-        return len(self.seqs)
-
-    def __getitem__(self, idx: int):
-        x = torch.tensor(self.seqs[idx], dtype=torch.long)
-        return x
+from model import FFTNet
+from fftnet.data import TextFileDataset
+from fftnet.utils.config import build_model_from_config, load_config
+from fftnet.utils.storage import load_model, save_model
+from tokenizer import SimpleTokenizer
 
 
 def distill(model: FFTNet, teacher: AutoModelForCausalLM, dataset: Dataset, cfg: dict, args: argparse.Namespace) -> None:
@@ -65,6 +37,8 @@ def distill(model: FFTNet, teacher: AutoModelForCausalLM, dataset: Dataset, cfg:
             correct = 0
             count = 0
             for batch in loader:
+                if isinstance(batch, (list, tuple)):
+                    batch = batch[0]
                 batch = batch.to(device)
                 opt.zero_grad()
                 with torch.no_grad():
@@ -104,17 +78,34 @@ def main() -> None:
     parser.add_argument("--lr", type=float, default=1e-3)
     parser.add_argument("--teacher-model", default="gpt2")
     parser.add_argument("--save-name", default="distilled")
+    parser.add_argument("--data-path", required=True, help="Path to training text file")
+    parser.add_argument(
+        "--tokenizer-path", default="tokenizer.json", help="Path to load/save the tokenizer"
+    )
+    parser.add_argument("--vocab-size", type=int, default=5000)
     args = parser.parse_args()
 
     if args.resume:
         model, cfg = load_model(Path("weights") / args.resume)
+        tokenizer = SimpleTokenizer.load(args.tokenizer_path)
     else:
-        model, cfg = build_model(
-            "config/fiftynet_config.json", "config/fiftynet_modules.yaml"
-        )
+        tokenizer_path = Path(args.tokenizer_path)
+        if tokenizer_path.exists():
+            tokenizer = SimpleTokenizer.load(str(tokenizer_path))
+        else:
+            corpus = Path(args.data_path).read_text(encoding="utf-8")
+            tokenizer = SimpleTokenizer.train_from_iterator(
+                [corpus], vocab_size=args.vocab_size
+            )
+            tokenizer_path.parent.mkdir(parents=True, exist_ok=True)
+            tokenizer.save(str(tokenizer_path))
+
+        cfg = load_config("config/fiftynet_config.json", "config/fiftynet_modules.yaml")
+        cfg["vocab_size"] = len(tokenizer)
+        model = build_model_from_config(cfg)
 
     teacher = AutoModelForCausalLM.from_pretrained(args.teacher_model)
-    dataset = DummyWikiDataset(seq_len=args.seq_len)
+    dataset = TextFileDataset(args.data_path, tokenizer, seq_len=args.seq_len)
 
     distill(model, teacher, dataset, cfg, args)
 


### PR DESCRIPTION
## Summary
- Use real `TextFileDataset` with tokenizer support in `train_distill.py`
- Allow evaluation script to load tokenized text data
- Compare runs using tokenized text dataset for logit spectrum analysis

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689029c48fcc832487e82c8dd46717ec