### PR TITLE
Add benchmark scripts and CI workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,22 @@
+name: Benchmarks
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run benchmarks
+        run: |
+          python benchmarks/benchmark_fftnet_block.py
+          python benchmarks/benchmark_model.py

--- a/benchmarks/benchmark_fftnet_block.py
+++ b/benchmarks/benchmark_fftnet_block.py
@@ -1,0 +1,25 @@
+"""Benchmark throughput and memory usage of FFTNetBlock."""
+
+import os
+import sys
+import torch
+
+# Ensure repository root is on the path for direct execution
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from fftnet_block import FFTNetBlock
+from benchmarks.benchmark_utils import benchmark_module
+
+
+def main():
+    dim = 64
+    seq_len = 128
+    batch_size = 4
+    block = FFTNetBlock(dim)
+    dummy_input = torch.randn(batch_size, seq_len, dim)
+    throughput, mem_mb = benchmark_module(block, dummy_input)
+    print(f"FFTNetBlock: {throughput:.2f} it/s, peak memory {mem_mb:.2f} MB")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/benchmark_model.py
+++ b/benchmarks/benchmark_model.py
@@ -1,0 +1,27 @@
+"""Benchmark throughput and memory usage of the full FFTNet model."""
+
+import os
+import sys
+import torch
+
+# Ensure repository root is on the path for direct execution
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from model import FFTNet
+from benchmarks.benchmark_utils import benchmark_module
+
+
+def main():
+    vocab_size = 5000
+    dim = 64
+    num_blocks = 2
+    seq_len = 128
+    batch_size = 4
+    model = FFTNet(vocab_size, dim, num_blocks)
+    dummy_input = torch.randint(0, vocab_size, (batch_size, seq_len))
+    throughput, mem_mb = benchmark_module(model, dummy_input)
+    print(f"FFTNet: {throughput:.2f} it/s, peak memory {mem_mb:.2f} MB")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/benchmark_utils.py
+++ b/benchmarks/benchmark_utils.py
@@ -1,0 +1,29 @@
+import time
+import resource
+import torch
+
+
+def benchmark_module(module: torch.nn.Module, input_tensor: torch.Tensor, iterations: int = 10):
+    """Measure throughput (iterations/second) and peak memory usage in MB."""
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    module = module.to(device)
+    module.eval()
+    input_tensor = input_tensor.to(device)
+    if torch.cuda.is_available():
+        torch.cuda.reset_peak_memory_stats(device)
+    start_mem = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    start_time = time.time()
+    with torch.no_grad():
+        for _ in range(iterations):
+            module(input_tensor)
+            if torch.cuda.is_available():
+                torch.cuda.synchronize()
+    elapsed = time.time() - start_time
+    throughput = iterations / elapsed if elapsed > 0 else float("inf")
+    if torch.cuda.is_available():
+        mem_bytes = torch.cuda.max_memory_allocated(device)
+        mem_mb = mem_bytes / (1024 ** 2)
+    else:
+        end_mem = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        mem_mb = (end_mem - start_mem) / 1024
+    return throughput, mem_mb


### PR DESCRIPTION
## Summary
- add benchmark utilities and scripts for FFTNetBlock and full FFTNet
- integrate benchmark run into GitHub Actions

## Testing
- `pytest`
- `python benchmarks/benchmark_fftnet_block.py`
- `python benchmarks/benchmark_model.py`


------
https://chatgpt.com/codex/tasks/task_e_689029c965f08324827130da7b18bf3c