### PR TITLE
Refactor visualization helpers into utils module

### DIFF
--- a/fftnet/utils/visualization.py
+++ b/fftnet/utils/visualization.py
@@ -1,0 +1,33 @@
+"""Visualization utilities for FFTNet."""
+
+from __future__ import annotations
+
+import torch
+import matplotlib.pyplot as plt
+
+__all__ = ["plot_embedding_spectrum"]
+
+
+def plot_embedding_spectrum(embeddings: torch.Tensor) -> None:
+    """Plot average frequency magnitude across tokens in a sequence.
+
+    Parameters
+    ----------
+    embeddings:
+        Tensor of shape ``(batch, seq_len, dim)`` representing token embeddings.
+    """
+    if embeddings.ndim != 3:
+        raise ValueError("embeddings must be 3D [batch, seq_len, dim]")
+
+    with torch.no_grad():
+        freq = torch.fft.fft(embeddings, dim=1)
+        magnitude = freq.abs().mean(dim=(0, 2))
+
+    plt.figure()
+    plt.plot(torch.arange(magnitude.size(0)), magnitude.cpu())
+    plt.xlabel("Frequency index")
+    plt.ylabel("Magnitude")
+    plt.title("Average Frequency Spectrum")
+    plt.tight_layout()
+    plt.show()
+    plt.close()

--- a/fftnet_infer.py
+++ b/fftnet_infer.py
@@ -1,35 +1,10 @@
 import argparse
-import os
-import sys
 from pathlib import Path
 
 import torch
 
-# Allow importing utility modules from the scripts directory
-sys.path.append(os.path.join(os.path.dirname(__file__), 'scripts'))
-
 from tokenizer import SimpleTokenizer
-try:
-    from main import plot_embedding_spectrum as fft_visualizer  # type: ignore
-except Exception:  # pragma: no cover
-    # Fallback visualizer if scripts/main.py is not available
-    import matplotlib.pyplot as plt
-
-    def fft_visualizer(embeddings: torch.Tensor) -> None:
-        """Plot average frequency magnitude across tokens in a sequence."""
-        if embeddings.ndim != 3:
-            raise ValueError("embeddings must be 3D [batch, seq_len, dim]")
-        with torch.no_grad():
-            freq = torch.fft.fft(embeddings, dim=1)
-            magnitude = freq.abs().mean(dim=(0, 2))
-        plt.figure()
-        plt.plot(torch.arange(magnitude.size(0)), magnitude.cpu())
-        plt.xlabel("Frequency index")
-        plt.ylabel("Magnitude")
-        plt.title("Average Frequency Spectrum")
-        plt.tight_layout()
-        plt.show()
-        plt.close()
+from fftnet.utils.visualization import plot_embedding_spectrum as fft_visualizer
 
 
 from model import FFTNet

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -1,29 +1,10 @@
 import argparse
 import sys
 import torch
-import matplotlib.pyplot as plt
 
 from fftnet.utils import storage
 from fftnet.utils.config import build_model
-
-
-def plot_embedding_spectrum(embeddings: torch.Tensor) -> None:
-    """Plot average frequency magnitude across tokens in a sequence."""
-    if embeddings.ndim != 3:
-        raise ValueError("embeddings must be 3D [batch, seq_len, dim]")
-
-    with torch.no_grad():
-        freq = torch.fft.fft(embeddings, dim=1)
-        magnitude = freq.abs().mean(dim=(0, 2))
-
-    plt.figure()
-    plt.plot(torch.arange(magnitude.size(0)), magnitude.cpu())
-    plt.xlabel("Frequency index")
-    plt.ylabel("Magnitude")
-    plt.title("Average Frequency Spectrum")
-    plt.tight_layout()
-    plt.show()
-    plt.close()
+from fftnet.utils.visualization import plot_embedding_spectrum
 
 
 def main() -> None:

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,12 +1,9 @@
-import os
-import sys
 import torch
 import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
-sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'scripts'))
-from main import plot_embedding_spectrum
+from fftnet.utils.visualization import plot_embedding_spectrum
 
 
 def test_plot_embedding_spectrum():


### PR DESCRIPTION
## Summary
- add `fftnet.utils.visualization` module with `plot_embedding_spectrum`
- clean up `fftnet_infer.py` imports and keep a standard `main()` entrypoint
- update scripts and tests to use the shared visualization helper

## Testing
- `pytest >/tmp/pytest.log; tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68c4e41a93588324b860b8bdbe8da8bf