### PR TITLE
Add reproducible dataset split seed to training scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ before projecting back to token space.
 ```bash
 python scripts/train_fresh.py --data-path path/to/corpus.txt --epochs 1
 ```
+Set `--split-seed` to reproduce the train/validation split across runs.
 
 ### Inference
 

--- a/scripts/train_distill.py
+++ b/scripts/train_distill.py
@@ -151,6 +151,12 @@ def main() -> None:
         help="Fraction of data reserved for validation",
     )
     parser.add_argument(
+        "--split-seed",
+        type=int,
+        default=42,
+        help="Random seed to reproduce train/val splits",
+    )
+    parser.add_argument(
         "--patience",
         type=int,
         default=0,
@@ -187,7 +193,10 @@ def main() -> None:
 
     val_size = int(len(dataset) * args.val_split)
     train_size = len(dataset) - val_size
-    train_ds, val_ds = random_split(dataset, [train_size, val_size])
+    generator = torch.Generator().manual_seed(args.split_seed)
+    train_ds, val_ds = random_split(
+        dataset, [train_size, val_size], generator=generator
+    )
 
     if args.checkpoint_path is None:
         args.checkpoint_path = Path("weights") / f"{args.save_name}_best"

--- a/scripts/train_fresh.py
+++ b/scripts/train_fresh.py
@@ -151,6 +151,12 @@ def main() -> None:
         help="Fraction of data for validation if no val-data-path provided",
     )
     parser.add_argument(
+        "--split-seed",
+        type=int,
+        default=42,
+        help="Random seed to reproduce train/val splits",
+    )
+    parser.add_argument(
         "--patience",
         type=int,
         default=0,
@@ -187,7 +193,10 @@ def main() -> None:
     else:
         val_size = int(len(full_dataset) * args.val_split)
         train_size = len(full_dataset) - val_size
-        train_dataset, val_dataset = random_split(full_dataset, [train_size, val_size])
+        generator = torch.Generator().manual_seed(args.split_seed)
+        train_dataset, val_dataset = random_split(
+            full_dataset, [train_size, val_size], generator=generator
+        )
 
     if args.checkpoint_path is None:
         args.checkpoint_path = Path("weights") / f"{args.save_name}_best"


### PR DESCRIPTION
## Summary
- add `--split-seed` option to training scripts and seed `random_split` with a `torch.Generator`
- document how to reproduce dataset splits via `--split-seed`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c4e41bb7748324967b80ea1d8904c4