### PR TITLE
Add optional spectrum plot saving

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -1,14 +1,25 @@
 import argparse
+import os
 import sys
-import torch
+from typing import Optional
+
+import matplotlib
+if not os.environ.get("DISPLAY"):
+    matplotlib.use("Agg")
 import matplotlib.pyplot as plt
+import torch
 
 from fftnet.utils import storage
 from fftnet.utils.config import build_model
 
 
-def plot_embedding_spectrum(embeddings: torch.Tensor) -> None:
-    """Plot average frequency magnitude across tokens in a sequence."""
+def plot_embedding_spectrum(embeddings: torch.Tensor, save_path: Optional[str] = None) -> None:
+    """Plot average frequency magnitude across tokens in a sequence.
+
+    Args:
+        embeddings: Input embedding tensor of shape [batch, seq_len, dim].
+        save_path: If provided, write the plot to this path instead of showing.
+    """
     if embeddings.ndim != 3:
         raise ValueError("embeddings must be 3D [batch, seq_len, dim]")
 
@@ -22,13 +33,24 @@ def plot_embedding_spectrum(embeddings: torch.Tensor) -> None:
     plt.ylabel("Magnitude")
     plt.title("Average Frequency Spectrum")
     plt.tight_layout()
-    plt.show()
+    if save_path:
+        plt.savefig(save_path)
+    else:
+        plt.show()
     plt.close()
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="FFTNet demo")
     parser.add_argument("--model", metavar="VERSION", help="Load model version", nargs="?")
+    parser.add_argument(
+        "--save-plot",
+        metavar="PATH",
+        help=(
+            "Save spectrum image to PATH instead of displaying it. "
+            "When no display is available the plot is saved to PATH or 'spectrum.png' by default."
+        ),
+    )
     args = parser.parse_args()
 
     if args.model:
@@ -45,7 +67,12 @@ def main() -> None:
 
     input_ids = torch.randint(0, cfg["vocab_size"], (1, 8))
     embeddings = model.embedding(input_ids)
-    plot_embedding_spectrum(embeddings)
+
+    save_path = args.save_plot
+    if save_path is None and not os.environ.get("DISPLAY"):
+        save_path = "spectrum.png"
+
+    plot_embedding_spectrum(embeddings, save_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Enable headless plotting by switching to the Agg backend when no display is available
- Add `--save-plot PATH` flag to `scripts/main.py` to save the spectrum plot
- Automatically save plots to `spectrum.png` when running without a display

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4e41e86bc8324b200a10f07f80980