### PR TITLE
refactor: centralize visualization utilities

### DIFF
--- a/fftnet/utils/visualization.py
+++ b/fftnet/utils/visualization.py
@@ -2,19 +2,26 @@
 
 from __future__ import annotations
 
-import torch
+from pathlib import Path
+from typing import Optional
+
 import matplotlib.pyplot as plt
+import torch
 
 __all__ = ["plot_embedding_spectrum"]
 
 
-def plot_embedding_spectrum(embeddings: torch.Tensor) -> None:
+def plot_embedding_spectrum(
+    embeddings: torch.Tensor, save_path: Optional[str | Path] = None
+) -> None:
     """Plot average frequency magnitude across tokens in a sequence.
 
     Parameters
     ----------
     embeddings:
         Tensor of shape ``(batch, seq_len, dim)`` representing token embeddings.
+    save_path:
+        If provided, save the plot to this path instead of displaying it.
     """
     if embeddings.ndim != 3:
         raise ValueError("embeddings must be 3D [batch, seq_len, dim]")
@@ -29,5 +36,8 @@ def plot_embedding_spectrum(embeddings: torch.Tensor) -> None:
     plt.ylabel("Magnitude")
     plt.title("Average Frequency Spectrum")
     plt.tight_layout()
-    plt.show()
+    if save_path:
+        plt.savefig(save_path)
+    else:
+        plt.show()
     plt.close()

--- a/fftnet_infer.py
+++ b/fftnet_infer.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import torch
 
 from tokenizer import SimpleTokenizer
-from fftnet.utils.visualization import plot_embedding_spectrum as fft_visualizer
+from fftnet.utils.visualization import plot_embedding_spectrum
 
 
 from model import FFTNet
@@ -68,7 +68,7 @@ def main() -> None:
             print(f"{word}: {val:.4f}")
     else:  # spectrum
         embeddings = model.embedding(generated)
-        fft_visualizer(embeddings)
+        plot_embedding_spectrum(embeddings)
 
 
 if __name__ == "__main__":

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -1,45 +1,16 @@
 import argparse
 import os
 import sys
-from typing import Optional
 
 import matplotlib
 if not os.environ.get("DISPLAY"):
     matplotlib.use("Agg")
-import matplotlib.pyplot as plt
 
 import torch
 
 from fftnet.utils import storage
 from fftnet.utils.config import build_model
-
-
-
-def plot_embedding_spectrum(embeddings: torch.Tensor, save_path: Optional[str] = None) -> None:
-    """Plot average frequency magnitude across tokens in a sequence.
-
-    Args:
-        embeddings: Input embedding tensor of shape [batch, seq_len, dim].
-        save_path: If provided, write the plot to this path instead of showing.
-    """
-    if embeddings.ndim != 3:
-        raise ValueError("embeddings must be 3D [batch, seq_len, dim]")
-
-    with torch.no_grad():
-        freq = torch.fft.fft(embeddings, dim=1)
-        magnitude = freq.abs().mean(dim=(0, 2))
-
-    plt.figure()
-    plt.plot(torch.arange(magnitude.size(0)), magnitude.cpu())
-    plt.xlabel("Frequency index")
-    plt.ylabel("Magnitude")
-    plt.title("Average Frequency Spectrum")
-    plt.tight_layout()
-    if save_path:
-        plt.savefig(save_path)
-    else:
-        plt.show()
-    plt.close()
+from fftnet.utils.visualization import plot_embedding_spectrum
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- move spectrum plotting helper into `fftnet.utils.visualization`
- import visualization helper in `fftnet_infer.py` and `scripts/main.py`
- streamline CLI entry points

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5906c082883249802edf0a99e6f64