### PR TITLE
Use Agg backend and add save-plot option

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -4,8 +4,7 @@ import sys
 from typing import Optional
 
 import matplotlib
-if not os.environ.get("DISPLAY"):
-    matplotlib.use("Agg")
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
 import torch
@@ -43,7 +42,9 @@ def plot_embedding_spectrum(embeddings: torch.Tensor, save_path: Optional[str] =
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="FFTNet demo")
+    parser = argparse.ArgumentParser(
+        description="FFTNet demo. Saves spectrum when no display is available."
+    )
     parser.add_argument("--model", metavar="VERSION", help="Load model version", nargs="?")
     parser.add_argument(
         "--save-plot",


### PR DESCRIPTION
## Summary
- set matplotlib backend to Agg for headless-friendly plotting
- add `--save-plot` flag with automatic saving when no display is available

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5906c6c0c832480137536871d60a2