### PR TITLE
Add minimal inference test for generate and CLI modes

### DIFF
--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -10,7 +10,7 @@ import pytest
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from tokenizer import SimpleTokenizer
-from fftnet.utils.config import load_config, build_model_from_config
+from fftnet.utils.config import build_model_from_config
 from fftnet_infer import generate
 
 
@@ -26,8 +26,13 @@ def tiny_tokenizer(tmp_path):
 
 
 def _build_model(tokenizer: SimpleTokenizer):
-    cfg = load_config("config/fiftynet_config.json", "config/fiftynet_modules.yaml")
-    cfg["vocab_size"] = len(tokenizer)
+    cfg = {
+        "vocab_size": len(tokenizer),
+        "dim": 2,
+        "blocks": [
+            {"type": "FFTNetBlock", "name": "block_0"},
+        ],
+    }
     return build_model_from_config(cfg)
 
 


### PR DESCRIPTION
## Summary
- add unit test ensuring `generate` outputs tensors of expected shape on a tiny FFTNet model
- test CLI `fftnet_infer.py` runs in `text` and `spectrum` modes without errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5907300148324be6f112a2667d813